### PR TITLE
fix: remove timex package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.23.0
 require (
 	github.com/hamba/logger/v2 v2.8.0
 	github.com/hamba/statter/v2 v2.6.0
-	github.com/hamba/timex v1.2.0
 	github.com/json-iterator/go v1.1.12
 	github.com/segmentio/ksuid v1.0.4
 	github.com/stretchr/testify v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,6 @@ github.com/hamba/logger/v2 v2.8.0 h1:0JJnEhVW4sHGn4/9fPP0LsZXD2ytG+NrnrXCdM8/vmg
 github.com/hamba/logger/v2 v2.8.0/go.mod h1:V58KZPAmDEWi14dOZjbKDPFkdyvpGwxXtLzLkVTNBic=
 github.com/hamba/statter/v2 v2.6.0 h1:d64DL4p48xAW4M876jrtguuEFXFf6cDFJR0WxNCDKVI=
 github.com/hamba/statter/v2 v2.6.0/go.mod h1:5QpB06ilNfJNfXW5YYe4cHUlh1NGTjIlpKDv/nl7U8w=
-github.com/hamba/timex v1.2.0 h1:Q1SMJz38jg0y+De/5D/owwqaTOMlU1vAwYGn70n1ahs=
-github.com/hamba/timex v1.2.0/go.mod h1:dCLYOsXXo4mRHEEnkzZjGArTvK29prYcuKW/1QoVhAA=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/klauspost/compress v1.17.11 h1:In6xLpyWOi1+C7tXUUWv2ot1QvBjxevKAaI6IXrJmUc=

--- a/http/middleware/middleware.go
+++ b/http/middleware/middleware.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net"
 	"net/http"
+	"time"
 
 	"github.com/hamba/logger/v2"
 	"github.com/hamba/logger/v2/ctx"
@@ -13,7 +14,6 @@ import (
 	"github.com/hamba/statter/v2"
 	"github.com/hamba/statter/v2/reporter/prometheus"
 	"github.com/hamba/statter/v2/tags"
-	"github.com/hamba/timex/mono"
 	"github.com/segmentio/ksuid"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
@@ -82,9 +82,9 @@ func WithStats(name string, s *statter.Statter, h http.Handler) http.Handler {
 
 		wrap := newResponseWrapper(rw)
 
-		start := mono.Now()
+		start := time.Now()
 		h.ServeHTTP(wrap, req)
-		dur := mono.Since(start)
+		dur := time.Since(start)
 
 		t = append(t, tags.StatusCode("code-group", wrap.Status()))
 		t = append(t, tags.Int("code", wrap.Status()))


### PR DESCRIPTION
## Goal of this PR

This removes the use of `github.com/hamba/timex` as it no longer has a speed advantage.

```
name         old time/op    new time/op    delta
WithStats-8     164ns ±20%     158ns ±14%   ~     (p=0.529 n=10+10)

name         old alloc/op   new alloc/op   delta
WithStats-8     41.0B ± 0%     41.0B ± 0%   ~     (all equal)

name         old allocs/op  new allocs/op  delta
WithStats-8      4.00 ± 0%      4.00 ± 0%   ~     (all equal)
```

<!--
Fixes #
-->

## How did I test it?

<!-- A brief description the steps taken to test this pull request. -->
