### PR TITLE
chore: bump linter to v2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
         go-version: [ "1.23", "1.24" ]
     runs-on: ubuntu-latest
     env:
-      GOLANGCI_LINT_VERSION: v1.64.2
+      GOLANGCI_LINT_VERSION: v2.0.2
 
     steps:
       - name: Checkout code
@@ -26,7 +26,7 @@ jobs:
           go-version: ${{ matrix.go-version }}
 
       - name: Run linter
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,20 +1,22 @@
+version: "2"
 run:
   tests: false
-  timeout: 5m
 
-linters-settings:
-  cyclop:
-    max-complexity: 12
-    skip-tests: true
-  funlen:
-    lines: 80
-  gofumpt:
-    extra-rules: true
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - gofumpt
+    - goimports
+  settings:
+    gofumpt:
+      extra-rules: true
+  exclusions:
+    generated: lax
 
 linters:
-  enable-all: true
+  default: all
   disable:
-    - tenv # deprecated
     - contextcheck
     - depguard
     - err113
@@ -31,6 +33,10 @@ linters:
     - varnamelen
     - wrapcheck
     - wsl
-
-issues:
-  exclude-use-default: false
+  settings:
+    cyclop:
+      max-complexity: 12
+    funlen:
+      lines: 80
+  exclusions:
+    generated: lax


### PR DESCRIPTION
## Goal of this PR

This bumps the golangci-lint to v2

## How did I test it?

<!-- A brief description the steps taken to test this pull request. -->
